### PR TITLE
Copyright

### DIFF
--- a/UsercentricsAdapter/build.gradle.kts
+++ b/UsercentricsAdapter/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Chartboost, Inc.
+ * Copyright 2022-2023 Chartboost, Inc.
  * 
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file.

--- a/UsercentricsAdapter/src/main/AndroidManifest.xml
+++ b/UsercentricsAdapter/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-  Copyright 2023 Chartboost, Inc.
+  Copyright 2022-2023 Chartboost, Inc.
   
   Use of this source code is governed by an MIT-style
   license that can be found in the LICENSE file.

--- a/UsercentricsAdapter/src/main/java/com/chartboost/core/consent/usercentrics/UsercentricsAdapter.kt
+++ b/UsercentricsAdapter/src/main/java/com/chartboost/core/consent/usercentrics/UsercentricsAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Chartboost, Inc.
+ * Copyright 2022-2023 Chartboost, Inc.
  *
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Chartboost, Inc.
+ * Copyright 2022-2023 Chartboost, Inc.
  * 
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Chartboost, Inc.
+ * Copyright 2022-2023 Chartboost, Inc.
  * 
  * Use of this source code is governed by an MIT-style
  * license that can be found in the LICENSE file.


### PR DESCRIPTION
Fix this to include 2022 to be like iOS (https://github.com/search?q=repo%3AChartBoost%2Fchartboost-core-ios-consent-adapter-usercentrics%20copyright&type=code) but we can revert once we've settled this: https://chartboost.slack.com/archives/C0552DZSNGP/p1692644289605349